### PR TITLE
Prettify usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,13 @@ require (
 	github.com/crossplane/crossplane-runtime v0.8.0
 	github.com/crossplane/oam-kubernetes-runtime v0.0.8
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-logr/logr v0.1.0 // indirect
 	github.com/gosuri/uitable v0.0.4
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	gotest.tools v2.2.0+incompatible
 	helm.sh/helm/v3 v3.2.4

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	cmdutil "github.com/cloud-native-application/rudrx/pkg/cmd/util"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// NewOptionsCommand return bind command
+func NewOptionsCommand(flags *pflag.FlagSet, ioStreams cmdutil.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "options",
+		Short: "Displays rudr global options",
+		Args:  cobra.ExactArgs(0),
+	}
+
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		ioStreams.Info(fmt.Sprintf("The following options can be passed to any command:\n %s", flags.FlagUsages()))
+	})
+
+	return cmd
+}

--- a/pkg/cmd/options_test.go
+++ b/pkg/cmd/options_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+
+	cmdutil "github.com/cloud-native-application/rudrx/pkg/cmd/util"
+)
+
+func TestNewOptionsCommand(t *testing.T) {
+	expectedOutput := `The following options can be passed to any command:
+   -t, --testFlag string   this is a test flag
+
+`
+	iostream, _, outPut, _ := cmdutil.NewTestIOStreams()
+	flags := pflag.NewFlagSet("global", pflag.ContinueOnError)
+	flags.StringP("testFlag", "t", "", "this is a test flag")
+	cmd := NewOptionsCommand(flags, iostream)
+
+	assert.NoError(t, cmd.Execute(), "run rudrx options expected no error")
+	assert.Equal(t, expectedOutput, outPut.String(), "rudrx options expected output\n %s\n got\n%s",
+		outPut.String())
+}

--- a/pkg/cmd/trait_bind.go
+++ b/pkg/cmd/trait_bind.go
@@ -35,10 +35,12 @@ func NewCommandOptions(ioStreams cmdutil.IOStreams) *commandOptions {
 	return &commandOptions{IOStreams: ioStreams}
 }
 
-func AddTraitPlugins(parentCmd *cobra.Command, c client.Client, ioStreams cmdutil.IOStreams) error {
+func AddTraitPlugins(c client.Client, ioStreams cmdutil.IOStreams) ([]*cobra.Command, error) {
+	var traitPluginCommands []*cobra.Command
+
 	templates, err := plugins.GetTraitsFromCluster(context.TODO(), types.DefaultOAMNS, c)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	ctx := context.Background()
 	for _, tmp := range templates {
@@ -68,9 +70,10 @@ func AddTraitPlugins(parentCmd *cobra.Command, c client.Client, ioStreams cmduti
 		}
 
 		o.Template = tmp
-		parentCmd.AddCommand(pluginCmd)
+		traitPluginCommands = append(traitPluginCommands, pluginCmd)
 	}
-	return nil
+
+	return traitPluginCommands, nil
 }
 
 func (o *commandOptions) Complete(cmd *cobra.Command, args []string, ctx context.Context) error {

--- a/pkg/cmd/workload_run.go
+++ b/pkg/cmd/workload_run.go
@@ -36,10 +36,12 @@ func newRunOptions(ioStreams cmdutil.IOStreams) *runOptions {
 	return &runOptions{IOStreams: ioStreams}
 }
 
-func AddWorkloadPlugins(parentCmd *cobra.Command, c client.Client, ioStreams cmdutil.IOStreams) error {
+func AddWorkloadPlugins(c client.Client, ioStreams cmdutil.IOStreams) ([]*cobra.Command, error) {
+	var workloadPluginCommands []*cobra.Command
+
 	templates, err := plugins.GetWorkloadsFromCluster(context.TODO(), types.DefaultOAMNS, c)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, tmp := range templates {
@@ -69,9 +71,9 @@ func AddWorkloadPlugins(parentCmd *cobra.Command, c client.Client, ioStreams cmd
 		}
 
 		o.Template = tmp
-		parentCmd.AddCommand(pluginCmd)
+		workloadPluginCommands = append(workloadPluginCommands, pluginCmd)
 	}
-	return nil
+	return workloadPluginCommands, nil
 }
 
 func (o *runOptions) Complete(cmd *cobra.Command, args []string, ctx context.Context) error {

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -1,0 +1,363 @@
+package template
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+	"unicode"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	cmdutil "github.com/cloud-native-application/rudrx/pkg/cmd/util"
+)
+
+var rootCommand = "rudr"
+
+// usageTemplate used to render usage
+var usageTemplate = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+  {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasBaseCommands}}
+
+Base Commands:{{range .BaseCommands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAdvancedCommands}}
+
+Advanced Commands:{{range .AdvancedCommands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasWorkloadPluginCommands}}
+
+WorkloadPlugin Commands:{{range .WorkloadPluginCommands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasTraitPluginCommands}}
+
+TraitPlugin Commands:{{range .TraitPluginCommands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+
+// usageTemplate used to render help
+var helpTemplate = `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+
+var templateFuncs = template.FuncMap{
+	"trim":                    strings.TrimSpace,
+	"trimRightSpace":          trimRightSpace,
+	"trimTrailingWhitespaces": trimRightSpace,
+	"rpad":                    rpad,
+	"gt":                      cobra.Gt,
+	"eq":                      cobra.Eq,
+}
+
+// Templater render usage
+type Templater interface {
+	UsageFunc() func(cmd *cobra.Command) error
+	HelpFunc() func(*cobra.Command, []string)
+	AddCommandsAndFlags()
+}
+
+type templater struct {
+	// usage template
+	UsageTemplate string
+	// help template
+	HelpTemplate string
+	// toot command
+	RootCmd *cobra.Command
+	// base usage command
+	BaseCommands []*cobra.Command
+	// advanced usage command
+	AdvancedCommands []*cobra.Command
+	// WorkloadPlugin command
+	WorkloadPluginCommands []*cobra.Command
+	// TraitPlugin command
+	TraitPluginCommands []*cobra.Command
+	// a list of global command-line options
+	OptionsCommand *cobra.Command
+	// global flags used by all sub commands
+	GlobalFlags *pflag.FlagSet
+	// extra flags used by controller-runtime
+	ioStream cmdutil.IOStreams
+}
+
+// vars for template
+type templateVars struct {
+	*cobra.Command
+	baseCommands           []*cobra.Command
+	advancedCommands       []*cobra.Command
+	workloadPluginCommands []*cobra.Command
+	traitPluginCommands    []*cobra.Command
+	globalFlags            *pflag.FlagSet
+}
+
+// NewTemplater return templater
+func NewTemplater(rootCmd *cobra.Command, baseCommands, advancedCommands, workloadPluginCommands, traitPluginCommands []*cobra.Command,
+	optionsCommand *cobra.Command, globalFlags *pflag.FlagSet, ioStream cmdutil.IOStreams) Templater {
+	return &templater{
+		RootCmd:                rootCmd,
+		ioStream:               ioStream,
+		UsageTemplate:          usageTemplate,
+		HelpTemplate:           helpTemplate,
+		GlobalFlags:            globalFlags,
+		BaseCommands:           baseCommands,
+		AdvancedCommands:       advancedCommands,
+		OptionsCommand:         optionsCommand,
+		WorkloadPluginCommands: workloadPluginCommands,
+		TraitPluginCommands:    traitPluginCommands,
+	}
+}
+
+// UsageFunc render usage
+func (t *templater) UsageFunc() func(cmd *cobra.Command) error {
+	return func(cmd *cobra.Command) error {
+		tmp := template.Must(template.New("usage").Funcs(templateFuncs).Parse(t.UsageTemplate))
+		vars := &templateVars{
+			Command:                cmd,
+			baseCommands:           t.BaseCommands,
+			advancedCommands:       t.AdvancedCommands,
+			workloadPluginCommands: t.WorkloadPluginCommands,
+			traitPluginCommands:    t.TraitPluginCommands,
+			globalFlags:            t.GlobalFlags,
+		}
+
+		return tmp.Execute(t.ioStream.Out, vars)
+	}
+}
+
+// UsageFunc render usage
+func (t *templater) HelpFunc() func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, args []string) {
+		tmp := template.Must(template.New("help").Funcs(templateFuncs).Parse(t.HelpTemplate))
+		vars := &templateVars{
+			Command: cmd,
+		}
+
+		if err := tmp.Execute(t.ioStream.Out, vars); err != nil {
+			t.ioStream.Errorf("Render help error: %s", err)
+			os.Exit(1)
+		}
+	}
+}
+
+// AddCommandsAndFlags add sub commands and flags
+func (t *templater) AddCommandsAndFlags() {
+	t.RootCmd.AddCommand(t.BaseCommands...)
+	t.RootCmd.AddCommand(t.AdvancedCommands...)
+	t.RootCmd.AddCommand(t.WorkloadPluginCommands...)
+	t.RootCmd.AddCommand(t.TraitPluginCommands...)
+	t.RootCmd.AddCommand(t.OptionsCommand)
+
+	flags := t.RootCmd.PersistentFlags()
+	flags.AddFlagSet(t.GlobalFlags)
+}
+
+func (v *templateVars) HasAvailableSubCommands() bool {
+
+	return len(v.Commands()) != 0
+}
+
+// Commands root command filter filtes baseCommand, advancedCommands, workloadPluginCommands,
+// traitPluginCommands. child command not filter
+func (v *templateVars) Commands() []*cobra.Command {
+	if !v.isRoot() {
+		return v.Command.Commands()
+	}
+
+	commands := []*cobra.Command{}
+	baseCommandsMap := toCommandMap(v.baseCommands)
+	advancedCommandsMap := toCommandMap(v.advancedCommands)
+	workloadPluginCommandsMap := toCommandMap(v.workloadPluginCommands)
+	traitPluginCommandsMap := toCommandMap(v.traitPluginCommands)
+
+	for _, command := range v.Command.Commands() {
+		if advancedCommandsMap[command] {
+			continue
+		}
+		if baseCommandsMap[command] {
+			continue
+		}
+		if workloadPluginCommandsMap[command] {
+			continue
+		}
+		if traitPluginCommandsMap[command] {
+			continue
+		}
+		commands = append(commands, command)
+	}
+
+	return commands
+}
+
+// HasBaseCommands BaseCommands not empty
+func (v *templateVars) HasBaseCommands() bool {
+	return len(v.BaseCommands()) != 0
+}
+
+// HasBaseCommands BaseCommands not empty
+func (v *templateVars) BaseCommands() []*cobra.Command {
+	baseCommands := []*cobra.Command{}
+	if !v.isRoot() {
+		return baseCommands
+	}
+
+	// the root command show base command and advanced command
+	// sub command show availad command only
+	baseCommands = v.baseCommands
+
+	return baseCommands
+}
+
+// HasAdvancedCommands AdvancedCommands not empty
+func (v *templateVars) HasAdvancedCommands() bool {
+	return len(v.AdvancedCommands()) != 0
+}
+
+func (v *templateVars) AdvancedCommands() []*cobra.Command {
+	advancedCommands := []*cobra.Command{}
+
+	if !v.isRoot() {
+		return advancedCommands
+	}
+
+	// the root command show base command and advanced command
+	// sub command show availad command only
+	advancedCommands = v.advancedCommands
+
+	return advancedCommands
+}
+
+// HasWorkloadPluginCommands AdvancedCommands not empty
+func (v *templateVars) HasWorkloadPluginCommands() bool {
+	return len(v.WorkloadPluginCommands()) != 0
+}
+
+func (v *templateVars) WorkloadPluginCommands() []*cobra.Command {
+	workloadPluginCommands := []*cobra.Command{}
+
+	if !v.isRoot() {
+		return workloadPluginCommands
+	}
+
+	// the root command show base command and advanced command
+	// sub command show availad command only
+	workloadPluginCommands = v.workloadPluginCommands
+
+	return workloadPluginCommands
+}
+
+// HasTraitPluginCommands AdvancedCommands not empty
+func (v *templateVars) HasTraitPluginCommands() bool {
+	return len(v.TraitPluginCommands()) != 0
+}
+
+func (v *templateVars) TraitPluginCommands() []*cobra.Command {
+	traitPluginCommands := []*cobra.Command{}
+
+	if !v.isRoot() {
+		return traitPluginCommands
+	}
+
+	// the root command show base command and advanced command
+	// sub command show availad command only
+	traitPluginCommands = v.traitPluginCommands
+
+	return traitPluginCommands
+}
+
+// HasAvailableInheritedFlags Commands not empty after filted
+// baseCommand and advancedCommands
+func (v *templateVars) HasAvailableLocalFlags() bool {
+	if !v.isRoot() {
+		return v.Command.LocalFlags().HasAvailableFlags()
+	}
+	return v.LocalFlags().HasAvailableFlags()
+}
+
+// InheritedFlags filter extral flgas
+func (v *templateVars) LocalFlags() *pflag.FlagSet {
+	if !v.isRoot() {
+		return v.Command.LocalFlags()
+	}
+
+	tmpFlagSet := pflag.NewFlagSet("tmp", pflag.ContinueOnError)
+	globalFlagMap := make(map[*pflag.Flag]bool)
+	v.globalFlags.VisitAll(func(flag *pflag.Flag) {
+		globalFlagMap[flag] = true
+	})
+
+	v.Command.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+		if globalFlagMap[flag] {
+			return
+		}
+		tmpFlagSet.AddFlag(flag)
+	})
+
+	return tmpFlagSet
+}
+
+// HasAvailableInheritedFlags Commands not empty after filted
+// baseCommand and advancedCommands
+func (v *templateVars) HasAvailableInheritedFlags() bool {
+	return v.InheritedFlags().HasAvailableFlags()
+}
+
+// InheritedFlags filter extral flgas
+func (v *templateVars) InheritedFlags() *pflag.FlagSet {
+	tmpFlagSet := pflag.NewFlagSet("tmp", pflag.ContinueOnError)
+	globalFlagMap := make(map[*pflag.Flag]bool)
+	v.globalFlags.VisitAll(func(flag *pflag.Flag) {
+		globalFlagMap[flag] = true
+	})
+
+	v.Command.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if globalFlagMap[flag] {
+			return
+		}
+		tmpFlagSet.AddFlag(flag)
+	})
+
+	return tmpFlagSet
+}
+
+// check current command is root command
+func (v *templateVars) isRoot() bool {
+	return v.Name() == rootCommand
+}
+
+func trimRightSpace(s string) string {
+	return strings.TrimRightFunc(s, unicode.IsSpace)
+}
+
+// rpad adds padding to the right of a string.
+func rpad(s string, padding int) string {
+	template := fmt.Sprintf("%%-%ds", padding)
+	return fmt.Sprintf(template, s)
+}
+
+// transform command array to map
+func toCommandMap(commands []*cobra.Command) map[*cobra.Command]bool {
+	commandsMap := make(map[*cobra.Command]bool)
+
+	for _, command := range commands {
+		commandsMap[command] = true
+	}
+
+	return commandsMap
+}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -1,0 +1,240 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"gotest.tools/assert"
+
+	cmdutil "github.com/cloud-native-application/rudrx/pkg/cmd/util"
+)
+
+var (
+	commandRunE = func(cmd *cobra.Command, args []string) error {
+		return nil
+	}
+	commandRun      = func(cmd *cobra.Command, args []string) {}
+	testRudrCommand = &cobra.Command{
+		Use:          "rudr",
+		Short:        "rudr is a command-line tool to use OAM based micro-app engine.",
+		Long:         "rudr is a command-line tool to use OAM based micro-app engine.",
+		Run:          commandRun,
+		SilenceUsage: true,
+	}
+	testRootCommand = &cobra.Command{
+		Use:          "root",
+		Short:        "root command.",
+		Long:         "root command long.",
+		SilenceUsage: true,
+	}
+	testSubCommand = &cobra.Command{
+		Use:   "sub",
+		Short: "sub command.",
+		Long:  "sub command long.",
+		RunE:  commandRunE,
+	}
+	testOptionsCommand = &cobra.Command{
+		Use:   "options",
+		Short: "options command.",
+		Long:  "options command long.",
+		RunE:  commandRunE,
+	}
+	testBaseCommands = []*cobra.Command{
+		&cobra.Command{
+			Use:   "base",
+			Short: "base command.",
+			Long:  "base command long.",
+			RunE:  commandRunE,
+		},
+	}
+	testAdvancedCommands = []*cobra.Command{
+		&cobra.Command{
+			Use:   "advanced",
+			Short: "advanced command.",
+			Long:  "advanced command long.",
+			RunE:  commandRunE,
+		},
+	}
+	testWorkloadPluginCommands = []*cobra.Command{
+		&cobra.Command{
+			Use:   "workloadPlugin",
+			Short: "workloadPlugin command.",
+			Long:  "workloadPlugin command long.",
+			RunE:  commandRunE,
+		},
+	}
+	testTraitPluginCommands = []*cobra.Command{
+		&cobra.Command{
+			Use:   "traitPlugin",
+			Short: "traitPlugin command.",
+			Long:  "traitPlugin command long.",
+			RunE:  commandRunE,
+		},
+	}
+	testGlobalFlags = pflag.NewFlagSet("global", pflag.ContinueOnError)
+)
+
+func TestTemplateVars(t *testing.T) {
+	// prepare
+	testRudrCommand.ResetCommands()
+	testRudrCommand.ResetFlags()
+	testRootCommand.ResetCommands()
+	testRootCommand.ResetFlags()
+
+	testGlobalFlags.StringP("testFlag", "t", "", "this is a test flag.")
+	testRudrCommand.AddCommand(testSubCommand)
+	testRootCommand.AddCommand(testSubCommand)
+
+	rudrTemplate := &templateVars{
+		Command:                testRudrCommand,
+		baseCommands:           testBaseCommands,
+		advancedCommands:       testAdvancedCommands,
+		workloadPluginCommands: testWorkloadPluginCommands,
+		traitPluginCommands:    testTraitPluginCommands,
+		globalFlags:            testGlobalFlags,
+	}
+	subTemplate := &templateVars{
+		Command:                testRootCommand,
+		baseCommands:           testBaseCommands,
+		advancedCommands:       testAdvancedCommands,
+		workloadPluginCommands: testWorkloadPluginCommands,
+		traitPluginCommands:    testTraitPluginCommands,
+		globalFlags:            testGlobalFlags,
+	}
+
+	assert.Equal(t, true, rudrTemplate.isRoot(), "Expected teplate is a root command.")
+	assert.Equal(t, false, subTemplate.isRoot(), "Expected teplate is not a root command.")
+	assert.Equal(t, 1, len(rudrTemplate.Commands()), "Expected has one command")
+	assert.Equal(t, 1, len(subTemplate.Commands()), "Expected has one command")
+
+	testRudrCommand.AddCommand(testBaseCommands...)
+	testRootCommand.AddCommand(testBaseCommands...)
+	assert.Equal(t, 1, len(rudrTemplate.Commands()), "Expected Root command filter base commands, has one command")
+	assert.Equal(t, true, rudrTemplate.HasBaseCommands(), "Expected has base command")
+	assert.Equal(t, 1, len(rudrTemplate.BaseCommands()), "Expected has one base command")
+	assert.Equal(t, 2, len(subTemplate.Commands()), "Expected Sub command doesn't filter base commands, Has two commands")
+	assert.Equal(t, false, subTemplate.HasBaseCommands(), "Expected has no base command")
+
+	testRudrCommand.AddCommand(testAdvancedCommands...)
+	testRootCommand.AddCommand(testAdvancedCommands...)
+	assert.Equal(t, 1, len(rudrTemplate.Commands()), "Expected Root command filter Advanced commands, has one command")
+	assert.Equal(t, true, rudrTemplate.HasAdvancedCommands(), "Expected has Advanced command")
+	assert.Equal(t, 1, len(rudrTemplate.AdvancedCommands()), "Expected has one Advanced command")
+	assert.Equal(t, 3, len(subTemplate.Commands()), "Expected Sub command doesn't filter Advanced commands, has three commands")
+	assert.Equal(t, false, subTemplate.HasAdvancedCommands(), "Expected has no Advanced command")
+
+	testRudrCommand.AddCommand(testWorkloadPluginCommands...)
+	testRootCommand.AddCommand(testWorkloadPluginCommands...)
+	assert.Equal(t, 1, len(rudrTemplate.Commands()), "Expected Root command filter WorkloadPlugin commands, has one command")
+	assert.Equal(t, true, rudrTemplate.HasWorkloadPluginCommands(), "Expected has WorkloadPlugin command")
+	assert.Equal(t, 1, len(rudrTemplate.WorkloadPluginCommands()), "Expected has one WorkloadPlugin command")
+	assert.Equal(t, 4, len(subTemplate.Commands()), "Expected Sub command filter WorkloadPlugin commands, has four commands")
+	assert.Equal(t, false, subTemplate.HasWorkloadPluginCommands(), "Expected has no WorkloadPlugin command")
+
+	testRudrCommand.AddCommand(testTraitPluginCommands...)
+	testRootCommand.AddCommand(testTraitPluginCommands...)
+	assert.Equal(t, 1, len(rudrTemplate.Commands()), "Expected Root command filter TraitPlugin commands, has one command")
+	assert.Equal(t, true, rudrTemplate.HasTraitPluginCommands(), "Expected has TraitPlugin command")
+	assert.Equal(t, 1, len(rudrTemplate.TraitPluginCommands()), "Expected has one TraitPlugin command")
+	assert.Equal(t, 5, len(subTemplate.Commands()), "Expected Sub command filter TraitPlugin commands, has five commands")
+	assert.Equal(t, false, subTemplate.HasTraitPluginCommands(), "Expected has no TraitPlugin command")
+
+	rootFlags := testRudrCommand.PersistentFlags()
+	subFlags := testRootCommand.PersistentFlags()
+	rootFlags.AddFlagSet(testGlobalFlags)
+	subFlags.StringP("rudrFlag", "r", "", "this is a rudr flag.")
+	subFlags.AddFlagSet(testGlobalFlags)
+
+	assert.Equal(t, false, rudrTemplate.HasAvailableLocalFlags(), "Expected has no flag")
+	assert.Equal(t, true, subTemplate.HasAvailableLocalFlags(), "Expected has flags")
+
+	rootFlagUsage := ``
+	subFlagUsage := `  -r, --rudrFlag string   this is a rudr flag.
+  -t, --testFlag string   this is a test flag.
+`
+	assert.Equal(t, rootFlagUsage, rudrTemplate.LocalFlags().FlagUsages(), "Expected root command's flag usage is: %s, actual is: %s",
+		rootFlagUsage, rudrTemplate.LocalFlags().FlagUsages())
+	assert.Equal(t, subFlagUsage, subTemplate.LocalFlags().FlagUsages(), "Expected sub command's flag usage is: %s, actual is: %s",
+		subFlagUsage, subTemplate.LocalFlags().FlagUsages())
+}
+
+func TestTemplater(t *testing.T) {
+	// prepare
+	testRudrCommand.ResetCommands()
+	testRudrCommand.ResetFlags()
+	testRootCommand.ResetCommands()
+	testRootCommand.ResetFlags()
+
+	iostream, _, outPut, _ := cmdutil.NewTestIOStreams()
+	rudrTemplate := NewTemplater(testRudrCommand, testBaseCommands, testAdvancedCommands, testWorkloadPluginCommands,
+		testTraitPluginCommands, testOptionsCommand, testGlobalFlags, iostream)
+	subTemplate := NewTemplater(testRootCommand, testBaseCommands, testAdvancedCommands, testWorkloadPluginCommands,
+		testTraitPluginCommands, testOptionsCommand, testGlobalFlags, iostream)
+	expectedRootCommandUsage := `rudr is a command-line tool to use OAM based micro-app engine.
+
+Usage:
+  rudr [flags]
+  rudr [command]
+
+Available Commands:
+  help           Help about any command
+  options        options command.
+
+Base Commands:
+  base           base command.
+
+Advanced Commands:
+  advanced       advanced command.
+
+WorkloadPlugin Commands:
+  workloadPlugin workloadPlugin command.
+
+TraitPlugin Commands:
+  traitPlugin    traitPlugin command.
+
+Flags:
+  -h, --help   help for rudr
+
+Use "rudr [command] --help" for more information about a command.
+`
+	expectedSubCommandUsage := `root command long.
+
+Usage:
+  root [command]
+
+Available Commands:
+  advanced       advanced command.
+  base           base command.
+  help           Help about any command
+  options        options command.
+  traitPlugin    traitPlugin command.
+  workloadPlugin workloadPlugin command.
+
+Flags:
+  -h, --help              help for root
+  -t, --testFlag string   this is a test flag.
+
+Use "root [command] --help" for more information about a command.
+`
+
+	rudrTemplate.AddCommandsAndFlags()
+	subTemplate.AddCommandsAndFlags()
+
+	testRudrCommand.SetUsageFunc(rudrTemplate.UsageFunc())
+	testRudrCommand.SetHelpFunc(rudrTemplate.HelpFunc())
+
+	testRudrCommand.SetArgs([]string{"-h"})
+	testRudrCommand.Execute()
+	assert.Equal(t, expectedRootCommandUsage, outPut.String(), "Expected root command help is:\n%s, actual is:\n%s",
+		expectedRootCommandUsage, outPut.String())
+
+	outPut.Reset()
+	testRootCommand.SetUsageFunc(rudrTemplate.UsageFunc())
+	testRootCommand.SetHelpFunc(rudrTemplate.HelpFunc())
+
+	testRootCommand.SetArgs([]string{"-h"})
+	testRootCommand.Execute()
+	assert.Equal(t, expectedSubCommandUsage, outPut.String(), "Expected help is:\n%s, actual is:\n%s",
+		expectedSubCommandUsage, outPut.String())
+}


### PR DESCRIPTION
Related issue #64 

1. Move global flags to the command options.
2. Classify commands

And the final effect is:

* `rudrx`

```
rudrx

rudr is a command-line tool to use OAM based micro-app engine.

Usage:
  rudr [flags]
  rudr [command]

Available Commands:
  help              Help about any command

Base Commands:
  traits            List traits
  workloads         List workloads
  init              Initialize RudrX on both client and server
  delete            Delete OAM Applications
  ls                List applications
  env:init          Create environments
  env:sw            Switch environments
  env:delete        Delete environment
  env               List environments
  version           Prints out build version information

WorkloadPlugin Commands:
  deployment:run    Run deployment workloads
  deployment:run    Run deployment workloads
  containerized:run Run containerized workloads
  deployment:run    Run deployment workloads
  deployment:run    Run deployment workloads

TraitPlugin Commands:
  ManualScaler      Attach ManualScaler trait to an app
  route             Attach route trait to an app
  SimpleRollout     Attach SimpleRollout trait to an app

Flags:
  -h, --help   help for rudr

Additional help topics:
  rudr options           Displays rudr global options

Use "rudr [command] --help" for more information about a command.
```

* `rudrx options`
```
rudrx options

The following options can be passed to any command:
       --as string                      Username to impersonate for the operation
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --cache-dir string               Default HTTP cache directory (default "/Users/dingxiaohua/.kube/http-cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -n, --namespace string               If present, the namespace scope for this CLI request
      --password string                Password for basic authentication to the API server
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
      --username string                Username for basic authentication to the API server
```

* Sub command usage, like `rudrx ls -h`
```
rudrx ls -h

List applications with workloads, traits, status and created time

Usage:
  rudr ls

Examples:
  rudr ls

Flags:
  -a, --app string   Application name
  -h, --help         help for ls
```