### PR TITLE
Fix label error

### DIFF
--- a/pkg/cmd/workload_run.go
+++ b/pkg/cmd/workload_run.go
@@ -151,7 +151,7 @@ func (o *runOptions) Run(cmd *cobra.Command) error {
 	component.Spec.Workload.Object = &unstructured.Unstructured{Object: obj}
 	component.Name = o.workloadName
 	component.Namespace = o.Env.Namespace
-	component.Labels = map[string]string{ComponentWorkloadDefLabel: o.workloadName}
+	component.Labels = map[string]string{ComponentWorkloadDefLabel: getWorkloadName(o.Template.DefinitionPath)}
 
 	appconfig.Name = o.workloadName
 	appconfig.Namespace = o.Env.Namespace
@@ -170,4 +170,18 @@ func (o *runOptions) Run(cmd *cobra.Command) error {
 	}
 	o.Info("SUCCEED")
 	return nil
+}
+
+// get workloaddefinition's name from template
+// definitionPath is: root/.vela/definitions/containerizedworkloads.core.oam.dev.cue
+// workloaddefinition name is containerizedworkloads.core.oam.dev
+func getWorkloadName(definitionPath string) string {
+	pathes := strings.Split(definitionPath, "/")
+
+	if len(pathes) == 0 {
+		return definitionPath
+	}
+
+	name := pathes[len(pathes)-1]
+	return strings.TrimRight(name, ".cue")
 }

--- a/pkg/cmd/workload_run_test.go
+++ b/pkg/cmd/workload_run_test.go
@@ -1,75 +1,24 @@
 package cmd
 
-/*
-func TestNewRunCommand(t *testing.T) {
-	// workloadTemplateExample2 := workloadTemplateExample.DeepCopy()
-	workloaddefExample2 := workloaddefExample.DeepCopy()
-	workloaddefExample2.Annotations["short"] = "containerized"
+import (
+	"fmt"
+	"testing"
 
-	cases := map[string]*test.CliTestCase{
-		"WorkloadNotDefinited": {
-			Resources: test.InitResources{
-				Create: []runtime.Object{
-					workloaddefExample.DeepCopy(),
-					//workloadTemplateExample.DeepCopy(),
-				},
-			},
-			WantException:  true,
-			ExpectedString: "You must specify a workload, like containerizedworkloads.core.oam.dev",
-			Args:           []string{},
-		},
-		"WorkloadShortWork": {
-			Resources: test.InitResources{
-				Create: []runtime.Object{
-					workloaddefExample2.DeepCopy(),
-					//workloadTemplateExample2.DeepCopy(),
-				},
-			},
-			WantException:  true,
-			ExpectedString: "You must specify a workload, like containerized",
-			Args:           []string{},
-		},
-		"PortFlagNotSet": {
-			Resources: test.InitResources{
-				Create: []runtime.Object{
-					workloaddefExample2.DeepCopy(),
-					//workloadTemplateExample2.DeepCopy(),
-				},
-			},
-			ExpectedResources: []runtime.Object{
-				appconfigExample,
-				componentExample,
-			},
-			WantException:  true,
-			ExpectedString: "Flag `port` is NOT set, please check and try again.",
-			Args:           []string{"containerized", "app2060", "nginx:1.9.4"},
-		},
-		"TemplateParametersWork": {
-			Resources: test.InitResources{
-				Create: []runtime.Object{
-					workloaddefExample2.DeepCopy(),
-					//workloadTemplateExample2.DeepCopy(),
-				},
-			},
-			ExpectedString: "-p, --port",
-			Args:           []string{"containerized", "-h"},
-		},
-		"AppConfigCreated": {
-			Resources: test.InitResources{
-				Create: []runtime.Object{
-					workloaddefExample2.DeepCopy(),
-					//workloadTemplateExample2.DeepCopy(),
-				},
-			},
-			ExpectedExistResources: []runtime.Object{
-				appconfigExample,
-				componentExample,
-			},
-			ExpectedOutput: "Creating AppConfig app2060\nSUCCEED\n",
-			Args:           []string{"containerized", "app2060", "nginx:1.9.4", "-p", "80"},
-		},
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetWorkloadName(t *testing.T) {
+	cases := [][]string{
+		[]string{"root/.vela/definitions/containerizedworkloads.core.oam.dev.cue", "containerizedworkloads.core.oam.dev"},
+		[]string{"root/.vela/definitions/containerizedworkloads.core.oam.dev", "containerizedworkloads.core.oam.dev"},
+		[]string{"", ""},
+		[]string{"containerizedworkloads.core.oam.dev.cue", "containerizedworkloads.core.oam.dev"},
+		[]string{"containerizedworkloads.core.oam.dev", "containerizedworkloads.core.oam.dev"},
 	}
 
-	test.NewCliTest(t, scheme, NewRunCommand, cases).Run()
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("Get workloadName case: %d", i), func(t *testing.T) {
+			assert.Equal(t, c[1], getWorkloadName(c[0]))
+		})
+	}
 }
-*/


### PR DESCRIPTION
Workloaddefinition for components is 

https://github.com/cloud-native-application/RudrX/blob/master/pkg/cmd/workload_run.go#L158
```
o.Component.Labels[ComponentWorkloadDefLabel] = workloadName
```

and the final result is 
```
kubectl get components.core.oam.dev -n default test -o yaml

....
  labels:
    vela.oam.dev/workloadDef: test
....
```
`vela.oam.dev/workloadDef` is the component name, isn't workload's name, this PR is to fix this bug.

I'm sorry to request PR #84, so I'm trying to add the UT test for `app:run` to avoid making mistakes again, but it needs a little work, and it seems can't be finished today, please allow me to add later.



