### PR TITLE
pretty help

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,45 @@ Usage:
   vela [command]
 
 Available Commands:
-  ManualScaler      Attach ManualScaler trait to an app
-  SimpleRollout     Attach SimpleRollout trait to an app
-  app:delete        Delete OAM Applications
-  app:ls            List applications
-  app:status        get status of an application
-  completion        Output shell completion code for the specified shell (bash or zsh)
-  containerized:run Run containerized workloads
-  deployment:run    Run deployment workloads
-  env               List environments
-  env:delete        Delete environment
-  env:init          Create environments
-  env:sw            Switch environments
-  help              Help about any command
-  init              Initialize RudrX on both client and server
-  route             Attach route trait to an app
-  traits            List traits
-  version           Prints out build version information
-  workloads         List workloads
+
+  Getting Started:
+    env       	List all environments
+    env:delete	Delete environment
+    env:init  	Create environment and switch to it
+    env:sw    	switch to another environment
+    version   	Prints out build version information
+
+  Applications:
+    app:delete [APPLICATION_NAME]	Delete OAM Applications
+    app:ls                       	List applications with workloads, traits, status and created time
+    app:status                   	get status of an application, including its workload and trait
+
+  Workloads:
+    containerized:run <appname> [args]	Run containerized workloads
+    deployment:run <appname> [args]   	Run deployment workloads
+
+  Traits:
+    manualscaler <appname> [args]	Attach manualscaler trait to an app
+    manualscaler:detach <appname>	Detach manualscaler trait from an app
+    rollout <appname> [args]     	Attach rollout trait to an app
+    rollout:detach <appname>     	Detach rollout trait from an app
+    route <appname> [args]       	Attach route trait to an app
+    route:detach <appname>       	Detach route trait from an app
+
+  Release:
+
+
+  Others:
+    addon:config	Set the addon center, default is local (built-in ones)
+    addon:ls    	List addons of workloads and traits
+
+  System:
+    completion [bash|zsh]	Output shell completion code for the specified shell (bash or zsh...
+    refresh              	Refresh and sync definition files from cluster
+    system:info          	show vela client and cluster version
+    system:init [flags]  	Install OAM runtime and vela builtin capabilities.
+
+Use "vela [command] --help" for more information about a command.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@ Vela is a command-line tool to use OAM based micro-app engine.
 ## Develop
 Check out [DEVELOPMENT.md](./DEVELOPMENT.md) to see how to develop with RudrX
 
-## Build `vela` binary
+## Install `vela` binary
+
 ```shell script
-$ go build -o /usr/local/bin/vela cmd/vela/main.go
-$ chmod +x /usr/local/bin/vela
+git clone git@github.com:cloud-native-application/RudrX.git
+cd RudrX
+make
+mv bin/vela /usr/local/bin
 ```
 
 ## Vela commands

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -126,3 +126,15 @@ func (app *Application) GetTraits(componentName string) (map[string]interface{},
 type EnvMeta struct {
 	Namespace string `json:"namespace"`
 }
+
+const (
+	TagCommandType = "commandType"
+
+	TypeStart     = "Getting Started"
+	TypeApp       = "Applications"
+	TypeWorkloads = "Workloads"
+	TypeTraits    = "Traits"
+	TypeRelease   = "Release"
+	TypeOthers    = "Others"
+	TypeSystem    = "System"
+)

--- a/pkg/builtin/deployment.go
+++ b/pkg/builtin/deployment.go
@@ -1,0 +1,40 @@
+package builtin
+
+var Deployment = `apiVersion: core.oam.dev/v1alpha2
+kind: WorkloadDefinition
+metadata:
+  name: deployments.apps
+  annotations:
+    oam.appengine.info/apiVersion: "apps/v1"
+    oam.appengine.info/kind: "Deployment"
+spec:
+  definitionRef:
+    name: deployments.apps
+  extension:
+    template: |
+      #Template: {
+      	apiVersion: "apps/v1"
+      	kind:       "Deployment"
+      	metadata: name: deployment.name
+      	spec: {
+      		containers: [{
+      			image: deployment.image
+      			name:  deployment.name
+      			env:   deployment.env
+      			ports: [{
+      				containerPort: deployment.port
+      				protocol:      "TCP"
+      				name:          "default"
+      			}]
+      		}]
+      	}
+      }
+      deployment: {
+      	name:  string
+      	image: string
+      	port:  *8080 | int
+      	env: [...{
+      		name:  string
+      		value: string
+      	}]
+      }`

--- a/pkg/cmd/addon.go
+++ b/pkg/cmd/addon.go
@@ -78,6 +78,9 @@ func NewAddonConfigCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 				ioStreams.Errorf("Unnecessary arguments are specified, please try again")
 			}
 		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeOthers,
+		},
 	}
 	return cmd
 }
@@ -103,6 +106,9 @@ func NewAddonListCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 				return err
 			}
 			return nil
+		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeOthers,
 		},
 	}
 	return cmd

--- a/pkg/cmd/admin.go
+++ b/pkg/cmd/admin.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os"
 
+	"github.com/cloud-native-application/rudrx/pkg/builtin"
+
 	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/cloud-native-application/rudrx/api/types"
@@ -62,13 +64,7 @@ var (
 	}
 
 	workloadResource = map[string]string{
-		"statefulset": "statefulsets.apps",
-		"daemonset":   "daemonsets.apps",
-		"deployment":  "deployments.apps",
-		"job":         "jobs.batch",
-		"secret":      "secrets",
-		"service":     "services",
-		"configmap":   "configmaps",
+		"deployment": builtin.Deployment,
 	}
 )
 

--- a/pkg/cmd/admin.go
+++ b/pkg/cmd/admin.go
@@ -38,14 +38,6 @@ var (
 	settings = cli.New()
 )
 
-const initDesc = `
-This command installs oam-kubernetes-runtime  onto your Kubernetes Cluster.
-As with the rest of the Vela commands, 'vela init' discovers Kubernetes clusters
-by reading $KUBECONFIG (default '~/.kube/config') and using the default context.
-When installing oam-kubernetes-runtime, 'vela init' will attempt to install the latest released
-version. 
-`
-
 type initCmd struct {
 	namespace string
 	out       io.Writer
@@ -84,10 +76,14 @@ func NewAdminInfoCommand(version string, ioStreams cmdutil.IOStreams) *cobra.Com
 	i := &infoCmd{out: ioStreams.Out}
 
 	cmd := &cobra.Command{
-		Use:   "admin:info",
+		Use:   "system:info",
 		Short: "show vela client and cluster version",
+		Long:  "show vela client and cluster version",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return i.run(version, ioStreams)
+		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeSystem,
 		},
 	}
 	return cmd
@@ -111,9 +107,9 @@ func NewAdminInitCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 	i := &initCmd{out: ioStreams.Out}
 
 	cmd := &cobra.Command{
-		Use:   "admin:init",
-		Short: "Initialize Vela on both client and server",
-		Long:  initDesc,
+		Use:   "system:init",
+		Short: "Initialize vela on both client and server",
+		Long:  "Install OAM runtime and vela builtin capabilities.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
 			if err != nil {
@@ -122,6 +118,9 @@ func NewAdminInitCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 			i.client = newClient
 			i.namespace = types.DefaultOAMNS
 			return i.run(ioStreams)
+		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeSystem,
 		},
 	}
 

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -2,20 +2,20 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/cloud-native-application/rudrx/api/types"
+	"github.com/spf13/cobra"
 )
 
-const completionDesc = `
-Output shell completion code for the specified shell (bash or zsh). 
+const completionDesc = `Output shell completion code for the specified shell (bash or zsh). 
 The shell code must be evaluated to provide interactive completion 
 of vela commands.
 `
 
-const bashCompDesc = `
-Generate the autocompletion script for Vela for the bash shell.
+const bashCompDesc = `Generate the autocompletion script for Vela for the bash shell.
 
 To load completions in your current shell session:
 $ source <(vela completion bash)
@@ -27,8 +27,7 @@ MacOS:
   $ vela completion bash > /usr/local/etc/bash_completion.d/vela
 `
 
-const zshCompDesc = `
-Generate the autocompletion script for Vela for the zsh shell.
+const zshCompDesc = `Generate the autocompletion script for Vela for the zsh shell.
 
 To load completions in your current shell session:
 $ source <(vela completion zsh)
@@ -43,6 +42,9 @@ func NewCompletionCommand() *cobra.Command {
 		Short: "Output shell completion code for the specified shell (bash or zsh)",
 		Long:  completionDesc,
 		Args:  cobra.NoArgs,
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeSystem,
+		},
 	}
 
 	bash := &cobra.Command{

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -31,6 +31,9 @@ func newDeleteCommand() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Short:                 "Delete OAM Applications",
 		Long:                  "Delete OAM Applications",
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeApp,
+		},
 		Example: `
   vela delete frontend
 `}

--- a/pkg/cmd/env.go
+++ b/pkg/cmd/env.go
@@ -32,6 +32,9 @@ func NewEnvCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ListEnvs(ctx, args, ioStreams)
 		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeStart,
+		},
 	}
 	cmd.SetOut(ioStreams.Out)
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
@@ -60,6 +63,9 @@ func NewEnvInitCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command
 			}
 			return CreateOrUpdateEnv(ctx, newClient, &envArgs, args, ioStreams)
 		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeStart,
+		},
 	}
 	cmd.SetOut(ioStreams.Out)
 	cmd.Flags().StringVar(&envArgs.Namespace, "namespace", "default", "specify K8s namespace for env")
@@ -77,6 +83,9 @@ func NewEnvDeleteCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return DeleteEnv(ctx, args, ioStreams)
 		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeStart,
+		},
 	}
 	cmd.SetOut(ioStreams.Out)
 	return cmd
@@ -92,6 +101,9 @@ func NewEnvSwitchCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 		Example:               `vela env:sw test`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return SwitchEnv(ctx, args, ioStreams)
+		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeStart,
 		},
 	}
 	cmd.SetOut(ioStreams.Out)

--- a/pkg/cmd/ls.go
+++ b/pkg/cmd/ls.go
@@ -32,6 +32,9 @@ func NewAppsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 			printApplicationList(ctx, newClient, "", env.Namespace)
 			return nil
 		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeApp,
+		},
 	}
 
 	cmd.PersistentFlags().StringP("app", "a", "", "Application name")

--- a/pkg/cmd/refresh.go
+++ b/pkg/cmd/refresh.go
@@ -28,6 +28,9 @@ func NewRefreshCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command
 			}
 			return RefreshDefinitions(ctx, newClient, ioStreams)
 		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeSystem,
+		},
 	}
 	cmd.SetOut(ioStreams.Out)
 	return cmd

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -39,6 +39,9 @@ func NewAppStatusCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 			}
 			return printApplicationStatus(ctx, newClient, ioStreams, appName, namespace)
 		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeApp,
+		},
 	}
 	cmd.SetOut(ioStreams.Out)
 	return cmd

--- a/pkg/cmd/trait_bind.go
+++ b/pkg/cmd/trait_bind.go
@@ -72,6 +72,9 @@ func AddTraitPlugins(parentCmd *cobra.Command, c types.Args, ioStreams cmdutil.I
 				}
 				return o.Run(cmd, ctx)
 			},
+			Annotations: map[string]string{
+				types.TagCommandType: types.TypeTraits,
+			},
 		}
 		pluginCmd.SetOut(o.Out)
 		for _, v := range tmp.Parameters {
@@ -195,6 +198,9 @@ func DetachTraitPlugins(parentCmd *cobra.Command, c types.Args, ioStreams cmduti
 					return err
 				}
 				return o.Run(cmd, ctx)
+			},
+			Annotations: map[string]string{
+				types.TagCommandType: types.TypeTraits,
 			},
 		}
 		pluginCmd.SetOut(o.Out)

--- a/pkg/cmd/workload_run.go
+++ b/pkg/cmd/workload_run.go
@@ -75,6 +75,9 @@ func AddWorkloadPlugins(parentCmd *cobra.Command, c types.Args, ioStreams cmduti
 				}
 				return o.Run(cmd)
 			},
+			Annotations: map[string]string{
+				types.TagCommandType: types.TypeWorkloads,
+			},
 		}
 		pluginCmd.SetOut(o.Out)
 		for _, v := range tmp.Parameters {

--- a/pkg/utils/logs/logs.go
+++ b/pkg/utils/logs/logs.go
@@ -18,6 +18,7 @@ package logs
 
 import (
 	"flag"
+	"io/ioutil"
 	"log"
 	"time"
 
@@ -41,8 +42,10 @@ func (writer KlogWriter) Write(data []byte) (n int, err error) {
 
 // InitLogs initializes logs the way we want for kubernetes.
 func InitLogs() {
-	log.SetOutput(KlogWriter{})
-	log.SetFlags(0)
+	log.SetOutput(ioutil.Discard)
+	klog.SetOutput(ioutil.Discard)
+	log.SetFlags(-1)
+
 	// The default glog flush interval is one second.
 	go wait.Until(klog.Flush, time.Second, wait.NeverStop)
 }


### PR DESCRIPTION
```
vela
✈️  A Micro App Plafrom for Kubernetes.

Usage:
  vela [flags]
  vela [command]

Available Commands:

  Getting Started:
    env       	List all environments
    env:delete	Delete environment
    env:init  	Create environment and switch to it
    env:sw    	switch to another environment
    version   	Prints out build version information

  Applications:
    app:delete [APPLICATION_NAME]	Delete OAM Applications
    app:ls                       	List applications with workloads, traits, status and created time
    app:status                   	get status of an application, including its workload and trait

  Workloads:
    containerized:run <appname> [args]	Run containerized workloads
    deployment:run <appname> [args]   	Run deployment workloads

  Traits:
    manualscaler <appname> [args]	Attach manualscaler trait to an app
    manualscaler:detach <appname>	Detach manualscaler trait from an app
    rollout <appname> [args]     	Attach rollout trait to an app
    rollout:detach <appname>     	Detach rollout trait from an app
    route <appname> [args]       	Attach route trait to an app
    route:detach <appname>       	Detach route trait from an app

  Release:


  Others:
    addon:config	Set the addon center, default is local (built-in ones)
    addon:ls    	List addons of workloads and traits

  System:
    completion [bash|zsh]	Output shell completion code for the specified shell (bash or zsh...
    refresh              	Refresh and sync definition files from cluster
    system:info          	show vela client and cluster version
    system:init [flags]  	Install OAM runtime and vela builtin capabilities.

Flags:
  -h, --help   help for vela

Use "vela [command] --help" for more information about a command.
```