### PR TITLE
Show command

### DIFF
--- a/cmd/vela/main.go
+++ b/cmd/vela/main.go
@@ -107,6 +107,7 @@ func newCommand() *cobra.Command {
 		cmd.NewAppsCommand(commandArgs, ioStream),
 		cmd.NewDeleteCommand(commandArgs, ioStream, os.Args[1:]),
 		cmd.NewAppStatusCommand(commandArgs, ioStream),
+		cmd.NewAppShowCommand(commandArgs, ioStream),
 
 		// Others
 		cmd.NewAddonConfigCommand(ioStream),

--- a/pkg/cmd/app_show.go
+++ b/pkg/cmd/app_show.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/cloud-native-application/rudrx/api/types"
+	cmdutil "github.com/cloud-native-application/rudrx/pkg/cmd/util"
+	corev1alpha2 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewAppShowCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+	ctx := context.Background()
+	cmd := &cobra.Command{
+		Use:     "app:show",
+		Short:   "get detail spec of your app",
+		Long:    "get detail spec of your app, including its workload and trait",
+		Example: `vela app:show <APPLICATION-NAME>`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			argsLength := len(args)
+			if argsLength == 0 {
+				ioStreams.Errorf("Hint: please specify an application")
+				os.Exit(1)
+			}
+			appName := args[0]
+			env, err := GetEnv()
+			if err != nil {
+				ioStreams.Errorf("Error: failed to get Env: %s", err)
+				return err
+			}
+
+			newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
+			if err != nil {
+				return err
+			}
+
+			return printApplication(ctx, newClient, cmd, env, appName)
+		},
+	}
+	cmd.SetOut(ioStreams.Out)
+	return cmd
+}
+
+func printApplication(ctx context.Context, c client.Client, cmd *cobra.Command, env *types.EnvMeta, appName string) error {
+	var application corev1alpha2.ApplicationConfiguration
+
+	if err := c.Get(ctx, client.ObjectKey{Name: appName, Namespace: env.Namespace}, &application); err != nil {
+		return fmt.Errorf("Fetch application with Err: %s", err)
+	}
+
+	workload, err := cmdutil.GetWorkloadDefinitionByName(context.TODO(), c, env.Namespace, appName)
+	if err != nil {
+		return fmt.Errorf("Fetch WorkloadDefinitionByName with Err: %s", err)
+	}
+
+	traitDefinitions := cmdutil.ListTraitDefinitionsByApplicationConfiguration(application)
+
+	cmd.Println("About:")
+	cmd.Println(workload.Name)
+	cmd.Println(len(traitDefinitions))
+	return nil
+}

--- a/pkg/cue/convert.go
+++ b/pkg/cue/convert.go
@@ -41,6 +41,35 @@ func Eval(templatePath, workloadType string, value map[string]interface{}) (stri
 	return data, nil
 }
 
+func Parse(templatePath, workloadType string, value map[string]interface{}) error {
+	r := cue.Runtime{}
+	template, err := r.Compile(templatePath, nil)
+	if err != nil {
+		return err
+	}
+
+	tempValue := template.Value()
+	appValue, err := tempValue.Fill(value, workloadType).Eval().Struct()
+	if err != nil {
+		return err
+	}
+
+	final, err := appValue.FieldByName(Template, true)
+	if err != nil {
+		return err
+	}
+	if err := final.Value.Validate(cue.Concrete(true), cue.Final()); err != nil {
+		return err
+	}
+	data, err := json.Marshal(final.Value)
+	if err != nil {
+		return err
+	}
+	println(string(data))
+
+	return nil
+}
+
 func GetParameters(templatePath string) ([]types.Parameter, string, error) {
 	r := cue.Runtime{}
 	template, err := r.Compile(templatePath, nil)


### PR DESCRIPTION
I have no idea to get parameter's origin value by `cue`, so this is my template resolve:

```
go run cmd/vela/main.go app:show test5


About:
  Appset: test5
  ENV: default
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test5
spec:
  containers:
  - env: []
    image: nginx
    name: test5
    ports:
    - containerPort: 8080
      name: default
      protocol: TCP
Traits:
- trait:
    apiVersion: core.oam.dev/v1alpha2
    kind: ManualScalerTrait
    metadata:
      name: test5-manualscaler-trait
    spec:
      replicaCount: 2
```