### PR TITLE
Fix version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# Rudrx version
-RUDRX_VERSION ?= 0.1.0
+# Vela version
+VELA_VERSION ?= 0.1.0
 # Repo info
 GIT_COMMIT ?= git-$(shell git rev-parse --short HEAD)
 
@@ -18,7 +18,7 @@ test: fmt vet
 
 # Build manager binary
 build: fmt vet
-	go build -ldflags "-X main.RudrxVersion=${RUDRX_VERSION} -X main.GitRevision=${GIT_COMMIT}" -o bin/vela cmd/vela/main.go
+	go build -ldflags "-X main.VelaVersion=${VELA_VERSION} -X main.GitRevision=${GIT_COMMIT}" -o bin/vela cmd/vela/main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: fmt vet


### PR DESCRIPTION
#117 
command version doesn't show correctly.

The Old

```
./bin/vela version                                                                                                                                                                         !10966
Version: UNKNOWN
GitRevision: git-f38c55a
GolangVersion: go1.14.2
```


fixed
```
./bin/vela version                                                                                                                                                                         !10979
Version: 0.1.0
GitRevision: git-f38c55a
GolangVersion: go1.14.2

```