### PR TITLE
Fix failure of bash autocomplete script

### DIFF
--- a/cmd/vela/main.go
+++ b/cmd/vela/main.go
@@ -62,7 +62,7 @@ func newCommand() *cobra.Command {
 	ioStream := cmdutil.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 
 	cmds := &cobra.Command{
-		Use:                "vela",
+		Use: "vela",
 		DisableFlagParsing: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			allCommands := cmd.Commands()

--- a/cmd/vela/main.go
+++ b/cmd/vela/main.go
@@ -62,6 +62,7 @@ func newCommand() *cobra.Command {
 	ioStream := cmdutil.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 
 	cmds := &cobra.Command{
+		Use:                "vela",
 		DisableFlagParsing: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			allCommands := cmd.Commands()

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -41,7 +41,7 @@ func NewCompletionCommand() *cobra.Command {
 		Use:   "completion [bash|zsh]",
 		Short: "Output shell completion code for the specified shell (bash or zsh)",
 		Long:  completionDesc,
-		Args:  cobra.NoArgs,
+		Args:  nil,
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeSystem,
 		},
@@ -51,7 +51,7 @@ func NewCompletionCommand() *cobra.Command {
 		Use:                   "bash",
 		Short:                 "generate autocompletions script for bash",
 		Long:                  bashCompDesc,
-		Args:                  cobra.NoArgs,
+		Args:                  nil,
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCompletionBash(os.Stdout, cmd)
@@ -62,7 +62,7 @@ func NewCompletionCommand() *cobra.Command {
 		Use:                   "zsh",
 		Short:                 "generate autocompletions script for zsh",
 		Long:                  zshCompDesc,
-		Args:                  cobra.NoArgs,
+		Args:                  nil,
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCompletionZsh(os.Stdout, cmd)
@@ -90,7 +90,6 @@ fi
 `
 		fmt.Fprintf(out, renamedBinaryHook, binary)
 	}
-
 	return err
 }
 


### PR DESCRIPTION
Fix #131 

Removing field `Use: "vela",` causes the bash autocomplete script to fail.