### PR TITLE
Print new line after `rudr app:ls` and display

### DIFF
--- a/pkg/server/util/middleware.go
+++ b/pkg/server/util/middleware.go
@@ -5,7 +5,7 @@ import (
 	"mime"
 
 	"github.com/gin-gonic/gin"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"go.uber.org/zap/zapcore"
 )
 


### PR DESCRIPTION
Fix #146 to print a new line after application
list. Display workload alias like `containerized`
instead of `ContainerizedWorkload` as users use
the alias to create an applicatin