### PR TITLE
App completion

### DIFF
--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("example test", func () {
+var _ = Describe("example test", func() {
 
 	It("Test get environment", func() {
 		w := httptest.NewRecorder()

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -60,6 +60,21 @@ func NewDeleteCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 		}
 		return o.Delete()
 	}
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		ctx := context.Background()
+		env, err := GetEnv(cmd)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return compListApplication(ctx, newClient, "", env.Namespace)
+	}
 	return cmd
 }
 

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -64,16 +64,7 @@ func NewDeleteCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		ctx := context.Background()
-		env, err := GetEnv(cmd)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		return compListApplication(ctx, newClient, "", env.Namespace)
+		return compListApplication(cmd, c)
 	}
 	return cmd
 }

--- a/pkg/cmd/ls.go
+++ b/pkg/cmd/ls.go
@@ -125,3 +125,16 @@ func RetrieveApplicationsByName(ctx context.Context, c client.Client, applicatio
 	}
 	return applicationMetaList, nil
 }
+
+// Provide dynamic auto-completion for Application names
+func compListApplication(ctx context.Context, c client.Client, appName string, namespace string) ([]string, cobra.ShellCompDirective) {
+	applicationMetaList, err := RetrieveApplicationsByName(ctx, c, appName, namespace)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	var choices []string
+	for _, a := range applicationMetaList {
+		choices = append(choices, a.Name)
+	}
+	return choices, cobra.ShellCompDirectiveNoFileComp
+}

--- a/pkg/cmd/ls.go
+++ b/pkg/cmd/ls.go
@@ -127,8 +127,17 @@ func RetrieveApplicationsByName(ctx context.Context, c client.Client, applicatio
 }
 
 // Provide dynamic auto-completion for Application names
-func compListApplication(ctx context.Context, c client.Client, appName string, namespace string) ([]string, cobra.ShellCompDirective) {
-	applicationMetaList, err := RetrieveApplicationsByName(ctx, c, appName, namespace)
+func compListApplication(cmd *cobra.Command, c types.Args) ([]string, cobra.ShellCompDirective) {
+	ctx := context.Background()
+	env, err := GetEnv(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	client, err := client.New(c.Config, client.Options{Scheme: c.Schema})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	applicationMetaList, err := RetrieveApplicationsByName(ctx, client, "", env.Namespace)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveDefault
 	}

--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -47,6 +47,21 @@ func NewAppShowCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command
 			types.TagCommandType: types.TypeApp,
 		},
 	}
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		ctx := context.Background()
+		env, err := GetEnv(cmd)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return compListApplication(ctx, newClient, "", env.Namespace)
+	}
 	cmd.SetOut(ioStreams.Out)
 	return cmd
 }

--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -51,16 +51,7 @@ func NewAppShowCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		ctx := context.Background()
-		env, err := GetEnv(cmd)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		return compListApplication(ctx, newClient, "", env.Namespace)
+		return compListApplication(cmd, c)
 	}
 	cmd.SetOut(ioStreams.Out)
 	return cmd

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -52,6 +52,21 @@ func NewAppStatusCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 			types.TagCommandType: types.TypeApp,
 		},
 	}
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		ctx := context.Background()
+		env, err := GetEnv(cmd)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return compListApplication(ctx, newClient, "", env.Namespace)
+	}
 	cmd.SetOut(ioStreams.Out)
 	return cmd
 }

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -56,16 +56,7 @@ func NewAppStatusCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		ctx := context.Background()
-		env, err := GetEnv(cmd)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		return compListApplication(ctx, newClient, "", env.Namespace)
+		return compListApplication(cmd, c)
 	}
 	cmd.SetOut(ioStreams.Out)
 	return cmd

--- a/pkg/cmd/trait.go
+++ b/pkg/cmd/trait.go
@@ -82,16 +82,7 @@ func AddTraitCommands(parentCmd *cobra.Command, c types.Args, ioStreams cmdutil.
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
-			ctx := context.Background()
-			env, err := GetEnv(cmd)
-			if err != nil {
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
-			newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
-			if err != nil {
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
-			return compListApplication(ctx, newClient, "", env.Namespace)
+			return compListApplication(cmd, c)
 		}
 		parentCmd.AddCommand(pluginCmd)
 	}
@@ -192,16 +183,7 @@ func AddTraitDetachCommands(parentCmd *cobra.Command, c types.Args, ioStreams cm
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
-			ctx := context.Background()
-			env, err := GetEnv(cmd)
-			if err != nil {
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
-			newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
-			if err != nil {
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
-			return compListApplication(ctx, newClient, "", env.Namespace)
+			return compListApplication(cmd, c)
 		}
 		pluginCmd.SetOut(ioStreams.Out)
 		parentCmd.AddCommand(pluginCmd)

--- a/pkg/cmd/trait.go
+++ b/pkg/cmd/trait.go
@@ -188,6 +188,21 @@ func AddTraitDetachCommands(parentCmd *cobra.Command, c types.Args, ioStreams cm
 		pluginCmd.Flags().StringP(App, "a", "", "create or add into an existing application group")
 		pluginCmd.Flags().BoolP(Staging, "s", false, "only save changes locally without real update application")
 
+		pluginCmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			ctx := context.Background()
+			env, err := GetEnv(cmd)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return compListApplication(ctx, newClient, "", env.Namespace)
+		}
 		pluginCmd.SetOut(ioStreams.Out)
 		parentCmd.AddCommand(pluginCmd)
 	}

--- a/pkg/cmd/trait.go
+++ b/pkg/cmd/trait.go
@@ -78,7 +78,21 @@ func AddTraitCommands(parentCmd *cobra.Command, c types.Args, ioStreams cmdutil.
 		}
 		pluginCmd.Flags().StringP(App, "a", "", "create or add into an existing application group")
 		pluginCmd.Flags().BoolP(Staging, "s", false, "only save changes locally without real update application")
-
+		pluginCmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			ctx := context.Background()
+			env, err := GetEnv(cmd)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return compListApplication(ctx, newClient, "", env.Namespace)
+		}
 		parentCmd.AddCommand(pluginCmd)
 	}
 	return nil


### PR DESCRIPTION
ISSUE #155 
Now `vela` can auto-completion Application names:

```shell
# app
$ vela app:delete [tab]
frontend   frontend1  frontend2
$ vela app:status [tab]
frontend   frontend1  frontend2
$ vela app:show [tab]
frontend   frontend1  frontend2
# traits
$ vela manualscaler [tab]
frontend   frontend1  frontend2
$ manualscaler:detach [tab]
frontend   frontend1  frontend2
```

Signed-off-by: guoxudong <sunnydog0826@gmail.com>