### PR TITLE
Fix api response for error cases

### DIFF
--- a/e2e/apiserver/apiserver_test.go
+++ b/e2e/apiserver/apiserver_test.go
@@ -29,7 +29,13 @@ var envWorldMeta = types.EnvMeta{
 	Namespace: "env-e2e-world",
 }
 
+var notExistedEnvMeta = types.EnvMeta{
+	Name:      "env-e2e-api-NOT-EXISTED-JUST-FOR-TEST",
+	Namespace: "env-e2e-api-NOT-EXISTED-JUST-FOR-TEST",
+}
+
 var _ = ginkgo.Describe("API Env", func() {
+	//API Env
 	e2e.APIEnvInitContext("post /envs/", envHelloMeta)
 
 	ginkgo.Context("get /envs/:envName", func() {
@@ -92,6 +98,24 @@ var _ = ginkgo.Describe("API Env", func() {
 			err = json.Unmarshal(result, &r)
 			gomega.Expect(http.StatusOK).To(gomega.Equal(r.Code))
 			gomega.Expect(r.Data.(string)).To(gomega.ContainSubstring(envWorldMeta.Name + " deleted"))
+		})
+	})
+
+	// API Application
+	ginkgo.Context("get /envs/:envName/apps/", func() {
+		ginkgo.It("should report error for not existed env", func() {
+			envName := notExistedEnvMeta.Name
+			url := fmt.Sprintf("/envs/%s/apps/", envName)
+			resp, err := http.Get(util.URL(url))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer resp.Body.Close()
+			result, err := ioutil.ReadAll(resp.Body)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			var r apis.Response
+			err = json.Unmarshal(result, &r)
+			gomega.Expect(http.StatusInternalServerError).To(gomega.Equal(r.Code))
+			expectedContent := fmt.Sprintf("env %s not exist", envName)
+			gomega.Expect(r.Data.(string)).To(gomega.ContainSubstring(expectedContent))
 		})
 	})
 })

--- a/pkg/oam/env.go
+++ b/pkg/oam/env.go
@@ -24,7 +24,7 @@ func GetEnvByName(name string) (*types.EnvMeta, error) {
 	data, err := ioutil.ReadFile(filepath.Join(system.GetEnvDirByName(name), system.EnvConfigName))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("%s not exist", name)
+			return nil, fmt.Errorf("env %s not exist", name)
 		}
 		return nil, err
 	}

--- a/pkg/server/handler/appHandlers.go
+++ b/pkg/server/handler/appHandlers.go
@@ -40,6 +40,7 @@ func ListApps(c *gin.Context) {
 	envMeta, err := oam.GetEnvByName(envName)
 	if err != nil {
 		util.HandleError(c, util.StatusInternalServerError, err)
+		return
 	}
 	namespace := envMeta.Namespace
 

--- a/pkg/server/util/errors.go
+++ b/pkg/server/util/errors.go
@@ -78,5 +78,6 @@ func SetErrorAndAbort(c *gin.Context, code Code, msg ...interface{}) {
 }
 
 func HandleError(c *gin.Context, code Code, msg ...interface{}) {
-	c.JSON(code.StatusCode(), gin.H{"error": ConstructError(code, msg...).Error()})
+	err := ConstructError(code, msg...)
+	AssembleResponse(c, nil, err)
 }


### PR DESCRIPTION
when hitting issue, the response struct should be the same as
normal response as below.
```
type Response struct {
	Code int         `json:"code"`
	Data interface{} `json:"data"`
}
```
Fix #169