### PR TITLE
fix not existed env successfully deleted

### DIFF
--- a/pkg/oam/env.go
+++ b/pkg/oam/env.go
@@ -140,7 +140,14 @@ func DeleteEnv(envName string) (string, error) {
 	if err != nil {
 		return message, err
 	}
-	if err = os.RemoveAll(filepath.Join(envdir, envName)); err != nil {
+	envPath := filepath.Join(envdir, envName)
+	if _, err := os.Stat(envPath); err != nil {
+		if os.IsNotExist(err) {
+			err = fmt.Errorf("%s does not exist", envName)
+			return message, err
+		}
+	}
+	if err = os.RemoveAll(envPath); err != nil {
 		return message, err
 	}
 	message = envName + " deleted"


### PR DESCRIPTION
fix: #163 
Delete not existed env would print tips normally now.
```
$ vela env:delete xxxx
xxxx does not exist
```