### PR TITLE
add a line break for 'vela xxx show' commands

### DIFF
--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -23,7 +23,7 @@ func NewAppShowCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsLength := len(args)
 			if argsLength == 0 {
-				ioStreams.Errorf("Hint: please specify the application name")
+				ioStreams.Errorf("Hint: please specify the application name\n")
 				os.Exit(1)
 			}
 			appName := args[0]
@@ -97,7 +97,7 @@ func NewCompShowCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsLength := len(args)
 			if argsLength == 0 {
-				ioStreams.Errorf("Hint: please specify the application name")
+				ioStreams.Errorf("Hint: please specify the application name\n")
 				os.Exit(1)
 			}
 			compName := args[0]


### PR DESCRIPTION
Before:
```
$ vela app show
Hint: please specify the application name**%**  

$ vela comp show
Hint: please specify the application name**%**  
```

After:
```
$ vela comp show
Hint: please specify the application name

$ vela app show 
Hint: please specify the application name
```