### PR TITLE
update example & add judgment for comp delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	k8s.io/cli-runtime v0.18.6
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
-	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 // indirect
 	k8s.io/kubectl v0.18.6 // indirect
 	k8s.io/utils v0.0.0-20200414100711-2df71ebbae66
 	rsc.io/letsencrypt v0.0.3 // indirect

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -66,11 +66,18 @@ func NewCompDeleteCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comm
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeApp,
 		},
-		Example: "vela comp delete frontend",
+		Example: "vela comp delete frontend -a frontend",
 	}
 	cmd.SetOut(ioStreams.Out)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		appName, err := cmd.Flags().GetString(App)
+		if err != nil {
+			return err
+		}
+		if appName == "" {
+			return errors.New("must specify name of application, please add flag -a")
+		}
 		newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
 		if err != nil {
 			return err
@@ -85,10 +92,6 @@ func NewCompDeleteCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comm
 			return errors.New("must specify name for the app")
 		}
 		o.CompName = args[0]
-		appName, err := cmd.Flags().GetString(App)
-		if err != nil {
-			return err
-		}
 		o.AppName = appName
 
 		ioStreams.Infof("Deleting Component '%s' from Application '%s'\n", o.CompName, o.AppName)


### PR DESCRIPTION
In command `vela comp delete frontend -a frontend` , flag `-a` is necessary.

update example and add judgement on flag `-a`

Signed-off-by: guoxudong <sunnydog0826@gmail.com>